### PR TITLE
parameterize boolean "sidenotes" option

### DIFF
--- a/cleanthesis.sty
+++ b/cleanthesis.sty
@@ -92,6 +92,11 @@
 \define@choicekey*[ct]{cthesis}{bibstyle}[\val\bibstylenr]{alphabetic,numeric,authoryear}[alphabetic]{\def\cthesis@bibstyle{#1}}
 \setkeys[ct]{cthesis}{bibstyle=alphabetic}
 
+% OPTION sidenotes
+% --> values = true|false
+\define@boolkey[ct]{cthesis}{sidenotes}[true]{}
+\setkeys[ct]{cthesis}{sidenotes=true}
+
 
 \DeclareOptionX*{
 	\PackageWarning{cleanthesis}{Unknown option ‘\CurrentOption’}%
@@ -259,15 +264,19 @@
 	%scale={0.86,0.94},				% 	- total body size (h,v)
 	nohead,							% 	- no header
 	includefoot,					% 	- include footer space
-	includemp,						% 	- include side note space
 	bindingoffset=0.5cm,			% 	- binding correction
 	top=2.25cm,						% 	- total body: top margin
 	left=3.75cm,					% 	- total body: left margin (odd pages)
 	right=0.75cm,					% 	- total body: right margin (odd pages)
 	bottom=1.5cm,					% 	- total body: bottom margin
-	marginparwidth=1.75cm,			% 	- width for side note
-	marginparsep=10pt,				% 	- space between notes and body text (content)
 	footskip=2cm,					% 	- footer skip size
+	\ifct@cthesis@sidenotes
+	%	{%
+			includemp,						% 	- include side note space
+			marginparwidth=1.75cm,			% 	- width for side note
+			marginparsep=10pt,				% 	- space between notes and body text (content)
+	%	}{}
+	\fi
 ]{geometry}
 %
 \RequirePackage[					% advanced quotes

--- a/thesis-example.tex
+++ b/thesis-example.tex
@@ -14,6 +14,7 @@
 	titlepage=on,				% own page for each title page
 	captions=tableabove,		% display table captions above the float env
 	draft=false,				% value for draft version
+	sidenotes=false,
 ]{scrreprt}%
 
 % **************************************************


### PR DESCRIPTION
Hi,

Thanks again for a fantastic style!  You inspired me to convert my dissertation to use it ;-) 

https://github.com/mrenoch/dangerousgifts/blob/master/README.md

I hope to create a few more PR's based on my experience. Here is the first. 

This PR doesn't quite work entirely, but it conveys what I am suggesting. I want to make it easier for users to to turn off the side notes margins (also highlighting that they are enabled in the first place).

I spent a bit of time trying to figure out where this extra padding originated, and I think this option would have helped me. 

I am just learning LaTeX, and am not certain why my syntax doesn't completely work - I can toggle the sidenotes when I set the boolean with \setkeys[ct]{cthesis}{sidenotes=true}, but when I set it in thesis-example.tex, the value isn't overridden. 

cheers!
