### PR TITLE
Used wrapfooter also for sectionmark.

### DIFF
--- a/cleanthesis.sty
+++ b/cleanthesis.sty
@@ -377,7 +377,11 @@
 		\footnotesize%
 		{\color{ctcolorfootermark}\textbf{\thesection}}%
 		\quad%
-		{\color{ctcolorfootertitle}#1}%
+		\ifct@cthesis@wrapfooter%
+			{\color{ctcolorfootertitle}\protect\parbox[t]{.7\textwidth}{#1}}%
+		\else%
+			{\color{ctcolorfootertitle}#1}%
+		\fi%
 	}%
 }
 %


### PR DESCRIPTION
This addresses issue #35 
I have used the same code which is already used for wrapping the chaptermark.

The hardcoded textwidth could be still improved. In my personal setup, I currently use `.825\textwidth` for the chaptermark and `.875\textwidth` for the section mark. However, I'm not sure how good this values fit to others.