### PR TITLE
Correct footer/header and hyperref/bookmark for unnumbered chapters

### DIFF
--- a/cleanthesis.sty
+++ b/cleanthesis.sty
@@ -364,9 +364,14 @@
 \renewcommand{\chaptermark}[1]{%
 	\markboth{%
 		\footnotesize%
-		% use \@chapapp instead of \chaptername to avoid 'Chapter A Appendix ...', thanks to @farbverlust (issue #47)
-		{\color{ctcolorfootermark}\textbf{\@chapapp\ \thechapter}}%
-		\quad%
+		% http://tex.stackexchange.com/questions/290400/remove-chapter-0-from-header-in-frontmatter-chapters-with-fancyhdr/290403
+    \ifnum \c@secnumdepth > \m@ne%
+      \if@mainmatter%
+        % use \@chapapp instead of \chaptername to avoid 'Chapter A Appendix ...', thanks to @farbverlust (issue #47)
+        {\color{ctcolorfootermark}\textbf{\@chapapp\ \thechapter}}%
+        \quad%
+      \fi%
+    \fi%
 		\ifct@cthesis@wrapfooter%
 			{\color{ctcolorfootertitle}\protect\parbox[t]{.7\textwidth}{#1}}%
 		\else%

--- a/content/abstract.tex
+++ b/content/abstract.tex
@@ -1,7 +1,6 @@
 % !TEX root = ../my-thesis.tex
 %
-\pdfbookmark[0]{Abstract}{Abstract}
-\chapter*{Abstract}
+\addchap*{Abstract}
 \label{sec:abstract}
 \vspace*{-10mm}
 

--- a/content/acknowledgement.tex
+++ b/content/acknowledgement.tex
@@ -1,7 +1,6 @@
 % !TEX root = ../my-thesis.tex
 %
-\pdfbookmark[0]{Acknowledgement}{Acknowledgement}
-\chapter*{Acknowledgement}
+\addchap*{Acknowledgement}
 \label{sec:acknowledgement}
 \vspace*{-10mm}
 

--- a/content/declaration.tex
+++ b/content/declaration.tex
@@ -3,8 +3,7 @@
 %************************************************
 % Declaration
 %************************************************
-\pdfbookmark[0]{Declaration}{Declaration}
-\chapter*{Declaration}
+\addchap*{Declaration}
 \label{sec:declaration}
 \thispagestyle{empty}
 


### PR DESCRIPTION
There is an issue with unnumbered chapters with more than one page: the footer/header of the previous chapter is repeated.

This can be fixed by using \addchap* instead of \chapter* (e.g. for abstract), and \addchap instead of \chapter* + \pdfbookmark[0] + \addcontentsline{toc}{chapter} (e.g. for unnumbered Introduction chapter).

Also, cleanthesis.sty must be fixed to prevent footnotes such as "Chapter 0 Introduction"

Typically:
\addchap*{Abstract} % no footer/header, no TOC
\addchap{Introduction} % footer/header and TOC
