### PR TITLE
Add \nobreak after \color in KOMA font definitions.

### DIFF
--- a/cleanthesis.sty
+++ b/cleanthesis.sty
@@ -491,13 +491,13 @@
 \newcommand{\book}{\fontfamily{pbk}\fontseries{m}\fontsize{11}{13}\selectfont}
 \newcommand{\tgherosfont}{\fontfamily{qhv}\selectfont}
 
-\newcommand{\thesispartlabelfont}{\color{ctcolorpartnum}\book\fontsize{60}{60}\selectfont}
-\newcommand{\thesispartfont}{\color{ctcolorparttext}\normalfont\huge \tgherosfont\selectfont}
-\newcommand{\thesischapterfont}{\color{ctcolorblack}\normalfont\huge \fontfamily{phv}\selectfont}
-%\newcommand{\thesissectionfont}{\color{ctcolormain}\LARGE\bfseries \tgherosfont}
-\newcommand{\thesissectionfont}{\color{ctcolorsection}\normalfont\LARGE \tgherosfont}
-\newcommand{\thesissubsectionfont}{\color{ctcolorsubsection}\normalfont\Large \tgherosfont}
-\newcommand{\thesisparagraphfont}{\color{ctcolorparagraph}\tgherosfont\small\bfseries}
+\newcommand{\thesispartlabelfont}{\color{ctcolorpartnum}\nobreak\book\fontsize{60}{60}\selectfont}
+\newcommand{\thesispartfont}{\color{ctcolorparttext}\nobreak\normalfont\huge \tgherosfont\selectfont}
+\newcommand{\thesischapterfont}{\color{ctcolorblack}\nobreak\normalfont\huge \fontfamily{phv}\selectfont}
+%\newcommand{\thesissectionfont}{\color{ctcolormain}\nobreak\LARGE\bfseries \tgherosfont}
+\newcommand{\thesissectionfont}{\color{ctcolorsection}\nobreak\normalfont\LARGE \tgherosfont}
+\newcommand{\thesissubsectionfont}{\color{ctcolorsubsection}\nobreak\normalfont\Large \tgherosfont}
+\newcommand{\thesisparagraphfont}{\color{ctcolorparagraph}\nobreak\tgherosfont\small\bfseries}
 
 \newcommand{\ctfontfooterpagenumber}{%
     \color{ctcolorfooterpage}%


### PR DESCRIPTION
This fixes #10 (wrong page breaks after sections)