### PR TITLE
chapter heading: fix bad box due to parskipfill

### DIFF
--- a/cleanthesis.sty
+++ b/cleanthesis.sty
@@ -636,6 +636,7 @@
             {\color{ctcolorchapternum}\fontsize{60}{60}\selectfont#1}%
         }%
     \end{minipage}%
+    {\parfillskip=0pt \par}%
 }
 \newcommand{\ctchaptertitle}[1]{%
     \usekomafont{chapter}%


### PR DESCRIPTION
parskipfill causes spaces to be added after the end of the paragraph,
resulting in a ugly badbox if parskip=half or parskip=full is used.

Before:

![before](https://user-images.githubusercontent.com/3192959/63742926-cb218080-c89a-11e9-9e23-aa87b9b40193.png)

After:

![after](https://user-images.githubusercontent.com/3192959/63742931-ceb50780-c89a-11e9-98c4-3f4760f3146e.png)
