### PR TITLE
example: include missing packages

### DIFF
--- a/example-thesis/my-thesis-setup.tex
+++ b/example-thesis/my-thesis-setup.tex
@@ -79,4 +79,6 @@
 % **************************************************
 % Other Packages
 % **************************************************
+\usepackage{listings}
 \usepackage{scrhack}
+\usepackage{tabularx}


### PR DESCRIPTION
The example won't compile if listings and tabularx aren't included.
Include them

Signed-off-by: Ralf Ramsauer <ralf@vmexit.de>