### PR TITLE
Fix displaying the pagenumber twice with pagestyle plain and oneside

### DIFF
--- a/cleanthesis.sty
+++ b/cleanthesis.sty
@@ -480,7 +480,7 @@
 \cefoot{}
 \refoot{}
 \lofoot{}
-\cofoot{}
+\cofoot[]{}
 \rofoot[%   > plain
     \ctfooterrightpagenumber%
 ]{%         > srcheadings


### PR DESCRIPTION
When using `twoside=false`, the page number was shown twice on pages with `pagestyle=plain` (See Issue #112). This is reproducible with the demo document by changing `twoside=true` to `twoside=false` in line 6 of `my-thesis.tex`. This minor change fixes this (see screenshots below).  

**Before:**
![image](https://user-images.githubusercontent.com/8270908/76559673-de471700-649f-11ea-9b3e-2336755a1fe1.png)  

**After:**
![image](https://user-images.githubusercontent.com/8270908/76559678-e43cf800-649f-11ea-8c81-b443f1c870f8.png)
