### PR TITLE
shift chapter number/line up/down according to font size

### DIFF
--- a/cleanthesis.sty
+++ b/cleanthesis.sty
@@ -627,7 +627,7 @@
     \usekomafont{chapter}%
     \begin{minipage}[t]{0.3\textwidth}%
         \raggedleft{%
-            {\color{ctcolorchapterline}\rule[-5pt]{2pt}{5cm}}%
+            {\color{ctcolorchapterline}\rule[-5pt]{2pt}{6.9em}}%
             \quad%
             {\color{ctcolorchapternum}\fontsize{60}{60}\selectfont#1}%
         }%


### PR DESCRIPTION
If a font size != 11pt was used, the chapter number/line was not adjusted accordingly. This caused the chapter title to be not aligned with the chapter number anymore. This fixes the issue by avoiding the absolute length value for the chapter line.