### PR TITLE
Fix table referencing by moving the label

### DIFF
--- a/example-thesis/content/chapter-appendix.tex
+++ b/example-thesis/content/chapter-appendix.tex
@@ -17,8 +17,8 @@
 		0			& 1				& 2				\\ \hline
 		3			& 4				& 5				\\ %\hline
 	\end{tabularx}
-	\label{tab:table1}
 	\caption{This is a caption text.}
+	\label{tab:table1}
 \end{table}
 
 \section{Appendix Section 2}
@@ -33,8 +33,8 @@
 		0			& 1				& 2				\\ \hline
 		3			& 4				& 5				\\ %\hline
 	\end{tabularx}
-	\label{tab:table2}
 	\caption{This is a caption text.}
+	\label{tab:table2}
 \end{table}
 
 \Blindtext[1][2]


### PR DESCRIPTION
Currently when starting off from the example thesis given, the table references will not work.

For a table reference to work properly the label needs to be defined after the caption. Otherwise `??` will be printed.